### PR TITLE
Initial Ender Dragon Spawn Delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,8 @@ gradle-app.setting
 run/
 runs/
 
+# Kotlin compiler cache/sessionfiles
+.kotlin/
+
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar

--- a/src/main/java/com/zephbyte/scaleddragonfight/mixin/EnderDragonFightAccessor.java
+++ b/src/main/java/com/zephbyte/scaleddragonfight/mixin/EnderDragonFightAccessor.java
@@ -1,0 +1,20 @@
+package com.zephbyte.scaleddragonfight.mixin;
+
+import net.minecraft.entity.boss.dragon.EnderDragonFight;
+import net.minecraft.entity.decoration.EndCrystalEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.List; // Import List
+
+@Mixin(EnderDragonFight.class)
+public interface EnderDragonFightAccessor {
+    /**
+     * Allows calling the private 'respawnDragon(List<EndCrystalEntity>)' method
+     * in EnderDragonFight.
+     * The method name in the @Invoker annotation must match the target method name
+     * as it appears after mappings (usually the deobfuscated name).
+     */
+    @Invoker("respawnDragon")
+    void callRespawnDragon(List<EndCrystalEntity> crystals);
+}

--- a/src/main/java/com/zephbyte/scaleddragonfight/mixin/EnderDragonFightMixin.java
+++ b/src/main/java/com/zephbyte/scaleddragonfight/mixin/EnderDragonFightMixin.java
@@ -1,0 +1,48 @@
+package com.zephbyte.scaleddragonfight.mixin;
+
+import com.zephbyte.scaleddragonfight.DragonEventHandler;
+import net.minecraft.entity.boss.dragon.EnderDragonEntity;
+import net.minecraft.entity.boss.dragon.EnderDragonFight;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+
+@Mixin(EnderDragonFight.class)
+public abstract class EnderDragonFightMixin {
+
+    @Shadow
+    @Final
+    private ServerWorld world;
+
+    @Shadow
+    public abstract boolean hasPreviouslyKilled();
+
+    @Inject(
+            method = "createDragon()Lnet/minecraft/entity/boss/dragon/EnderDragonEntity;", // Target createDragon()
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void scaleddragonfight_onPreCreateDragon(CallbackInfoReturnable<EnderDragonEntity> cir) { // Updated parameter
+        EnderDragonFight fightInstance = (EnderDragonFight) (Object) this;
+
+        // We only want to delay the *very first* dragon spawn in this world.
+        // hasPreviouslyKilled() is the best check for this.
+        if (!this.hasPreviouslyKilled()) {
+            // Call our handler. If it returns true, it means we are delaying the spawn.
+            if (DragonEventHandler.INSTANCE.onInitialDragonPreSpawn(fightInstance, this.world)) {
+                // If we are delaying, we cancel the original createDragon() method
+                // and make it return null for now, as the dragon entity isn't created yet.
+                cir.setReturnValue(null);
+                cir.cancel();
+            }
+        }
+        // If hasPreviouslyKilled() is true, or if onInitialDragonPreSpawn returns false
+        // (e.g., feature disabled, or it's our mod triggering the spawn after the delay),
+        // this injection does nothing, and createDragon() proceeds normally.
+    }
+}

--- a/src/main/kotlin/com/zephbyte/scaleddragonfight/ConfigManager.kt
+++ b/src/main/kotlin/com/zephbyte/scaleddragonfight/ConfigManager.kt
@@ -3,11 +3,11 @@ package com.zephbyte.scaleddragonfight
 import net.fabricmc.loader.api.FabricLoader
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.Properties
+import java.util.*
 
 object ConfigManager {
 
-    // Default configuration values
+    /*---- Default configuration values ----*/
     private const val DEFAULT_ENABLE_MOD = true
     private const val DEFAULT_SCALE_WITH_ONE_PLAYER = false
     private const val DEFAULT_COUNT_CREATIVE_MODE_PLAYERS = false
@@ -15,13 +15,23 @@ object ConfigManager {
     private const val DEFAULT_ADDITIONAL_HEALTH_PER_PLAYER = 100.0f
     private const val DEFAULT_ENABLE_BROADCAST = true
 
-    // Configurable values
+    // Values for delay dragon spawn
+    private const val DEFAULT_ENABLE_INITIAL_SPAWN_DELAY = true
+    private const val DEFAULT_INITIAL_SPAWN_DELAY_SECONDS = 60
+    private const val DEFAULT_SHOW_SPAWN_DELAY_COUNTDOWN = true
+
+    /*---- Configurable values ----*/
     var enableMod: Boolean = DEFAULT_ENABLE_MOD
     var scaleWithOnePlayer: Boolean = DEFAULT_SCALE_WITH_ONE_PLAYER
     var countCreativeModePlayers: Boolean = DEFAULT_COUNT_CREATIVE_MODE_PLAYERS
     var baseDragonHealth: Float = DEFAULT_BASE_DRAGON_HEALTH
     var additionalHealthPerPlayer: Float = DEFAULT_ADDITIONAL_HEALTH_PER_PLAYER
     var enableBroadcast: Boolean = DEFAULT_ENABLE_BROADCAST
+
+    // Values for delay dragon
+    var enableInitialSpawnDelay: Boolean = DEFAULT_ENABLE_INITIAL_SPAWN_DELAY
+    var initialSpawnDelaySeconds: Int = DEFAULT_INITIAL_SPAWN_DELAY_SECONDS
+    var showSpawnDelayCountdown: Boolean = DEFAULT_SHOW_SPAWN_DELAY_COUNTDOWN
 
     private val configFilePath: Path = FabricLoader.getInstance().configDir.resolve("$MOD_ID.properties")
 
@@ -35,20 +45,44 @@ object ConfigManager {
                     properties.load(inputStream)
                 }
 
-                enableMod = properties.getProperty("enableMod", DEFAULT_ENABLE_MOD.toString()).toBooleanStrictOrNull() ?: DEFAULT_ENABLE_MOD
-                scaleWithOnePlayer = properties.getProperty("scaleWithOnePlayer", DEFAULT_SCALE_WITH_ONE_PLAYER.toString()).toBooleanStrictOrNull() ?: DEFAULT_SCALE_WITH_ONE_PLAYER
-                countCreativeModePlayers = properties.getProperty("countCreativeModePlayers", DEFAULT_COUNT_CREATIVE_MODE_PLAYERS.toString()).toBooleanStrictOrNull() ?: DEFAULT_COUNT_CREATIVE_MODE_PLAYERS
-                baseDragonHealth = properties.getProperty("baseDragonHealth", DEFAULT_BASE_DRAGON_HEALTH.toString())
-                    .toFloatOrNull() ?: DEFAULT_BASE_DRAGON_HEALTH
-                additionalHealthPerPlayer = properties.getProperty("additionalHealthPerPlayer", DEFAULT_ADDITIONAL_HEALTH_PER_PLAYER.toString())
-                    .toFloatOrNull() ?: DEFAULT_ADDITIONAL_HEALTH_PER_PLAYER
-                enableBroadcast = properties.getProperty("enableBroadcast", DEFAULT_ENABLE_BROADCAST.toString()).toBooleanStrictOrNull() ?: DEFAULT_ENABLE_BROADCAST
+                /*---- Load configuration values ----*/
+                enableMod = properties.getProperty("enableMod", DEFAULT_ENABLE_MOD.toString()).toBooleanStrictOrNull()
+                    ?: DEFAULT_ENABLE_MOD
+                scaleWithOnePlayer =
+                    properties.getProperty("scaleWithOnePlayer", DEFAULT_SCALE_WITH_ONE_PLAYER.toString())
+                        .toBooleanStrictOrNull() ?: DEFAULT_SCALE_WITH_ONE_PLAYER
+                countCreativeModePlayers =
+                    properties.getProperty("countCreativeModePlayers", DEFAULT_COUNT_CREATIVE_MODE_PLAYERS.toString())
+                        .toBooleanStrictOrNull() ?: DEFAULT_COUNT_CREATIVE_MODE_PLAYERS
+                baseDragonHealth =
+                    properties.getProperty("baseDragonHealth", DEFAULT_BASE_DRAGON_HEALTH.toString()).toFloatOrNull()
+                        ?: DEFAULT_BASE_DRAGON_HEALTH
+                additionalHealthPerPlayer =
+                    properties.getProperty("additionalHealthPerPlayer", DEFAULT_ADDITIONAL_HEALTH_PER_PLAYER.toString())
+                        .toFloatOrNull() ?: DEFAULT_ADDITIONAL_HEALTH_PER_PLAYER
+                enableBroadcast = properties.getProperty("enableBroadcast", DEFAULT_ENABLE_BROADCAST.toString())
+                    .toBooleanStrictOrNull() ?: DEFAULT_ENABLE_BROADCAST
+
+                // Values for delay dragon spawn
+                enableInitialSpawnDelay =
+                    properties.getProperty("enableInitialSpawnDelay", DEFAULT_ENABLE_INITIAL_SPAWN_DELAY.toString())
+                        .toBooleanStrictOrNull() ?: DEFAULT_ENABLE_INITIAL_SPAWN_DELAY
+                initialSpawnDelaySeconds =
+                    properties.getProperty("initialSpawnDelaySeconds", DEFAULT_INITIAL_SPAWN_DELAY_SECONDS.toString())
+                        .toIntOrNull() ?: DEFAULT_INITIAL_SPAWN_DELAY_SECONDS
+                showSpawnDelayCountdown =
+                    properties.getProperty("showSpawnDelayCountdown", DEFAULT_SHOW_SPAWN_DELAY_COUNTDOWN.toString())
+                        .toBooleanStrictOrNull() ?: DEFAULT_SHOW_SPAWN_DELAY_COUNTDOWN
+
 
                 LOGGER.info("Configuration loaded: Mod Enabled = $enableMod, Scale w/ 1 Player = $scaleWithOnePlayer, Count Creative = $countCreativeModePlayers, Base Health = $baseDragonHealth, Additional Health/Player = $additionalHealthPerPlayer, Enable Broadcast = $enableBroadcast")
                 // Ensure config file is up-to-date with current or default values if parsing failed for some
                 saveConfig()
             } catch (e: Exception) {
-                LOGGER.error("Failed to load configuration for $MOD_ID. Using default values and attempting to save a new config file.", e)
+                LOGGER.error(
+                    "Failed to load configuration for $MOD_ID. Using default values and attempting to save a new config file.",
+                    e
+                )
                 resetToDefaultsAndSave()
             }
         } else {
@@ -61,12 +95,18 @@ object ConfigManager {
         LOGGER.info("Saving Scaled Dragon Fight configuration...")
         val properties = Properties()
 
+        /*---- Save configuration values ----*/
         properties.setProperty("enableMod", enableMod.toString())
         properties.setProperty("scaleWithOnePlayer", scaleWithOnePlayer.toString())
         properties.setProperty("countCreativeModePlayers", countCreativeModePlayers.toString())
         properties.setProperty("baseDragonHealth", baseDragonHealth.toString())
         properties.setProperty("additionalHealthPerPlayer", additionalHealthPerPlayer.toString())
         properties.setProperty("enableBroadcast", enableBroadcast.toString())
+
+        // Values for delay dragon
+        properties.setProperty("enableInitialSpawnDelay", enableInitialSpawnDelay.toString())
+        properties.setProperty("initialSpawnDelaySeconds", initialSpawnDelaySeconds.toString())
+        properties.setProperty("showSpawnDelayCountdown", showSpawnDelayCountdown.toString())
 
         val comments = """
             Scaled Dragon Fight Configuration
@@ -86,6 +126,12 @@ object ConfigManager {
                               (Default: $DEFAULT_SCALE_WITH_ONE_PLAYER)
             countCreativeModePlayers: If true, players in creative mode will be counted when scaling health. (Default: $DEFAULT_COUNT_CREATIVE_MODE_PLAYERS)
             enableBroadcast: If true, a message will be broadcast when the scaled dragon spawns. (Default: $DEFAULT_ENABLE_BROADCAST)
+            
+            --- Initial Spawn Delay ---
+            enableInitialSpawnDelay: If true, the very first Ender Dragon spawn in The End will be delayed. (Default: $DEFAULT_ENABLE_INITIAL_SPAWN_DELAY)
+            initialSpawnDelaySeconds: How many seconds to delay the initial dragon spawn. (Default: $DEFAULT_INITIAL_SPAWN_DELAY_SECONDS)
+            showSpawnDelayCountdown: If true, a countdown will be shown on players' XP bars in The End during the delay. (Default: $DEFAULT_SHOW_SPAWN_DELAY_COUNTDOWN)
+            \n
         """.trimIndent()
 
         try {
@@ -99,12 +145,18 @@ object ConfigManager {
     }
 
     private fun resetToDefaultsAndSave() {
+        /*---- Reset configuration values to defaults ----*/
         enableMod = DEFAULT_ENABLE_MOD
         scaleWithOnePlayer = DEFAULT_SCALE_WITH_ONE_PLAYER
         countCreativeModePlayers = DEFAULT_COUNT_CREATIVE_MODE_PLAYERS
         baseDragonHealth = DEFAULT_BASE_DRAGON_HEALTH
         additionalHealthPerPlayer = DEFAULT_ADDITIONAL_HEALTH_PER_PLAYER
         enableBroadcast = DEFAULT_ENABLE_BROADCAST
+
+        // Values for delay dragon
+        enableInitialSpawnDelay = DEFAULT_ENABLE_INITIAL_SPAWN_DELAY
+        initialSpawnDelaySeconds = DEFAULT_INITIAL_SPAWN_DELAY_SECONDS
+        showSpawnDelayCountdown = DEFAULT_SHOW_SPAWN_DELAY_COUNTDOWN
         saveConfig()
     }
 }

--- a/src/main/kotlin/com/zephbyte/scaleddragonfight/DragonEventHandler.kt
+++ b/src/main/kotlin/com/zephbyte/scaleddragonfight/DragonEventHandler.kt
@@ -1,12 +1,27 @@
 package com.zephbyte.scaleddragonfight
 
 import com.zephbyte.scaleddragonfight.ConfigManager.enableMod // Direct access to config
+import com.zephbyte.scaleddragonfight.mixin.EnderDragonFightAccessor
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
 import net.minecraft.entity.boss.dragon.EnderDragonEntity
+import net.minecraft.entity.boss.dragon.EnderDragonFight
+import net.minecraft.entity.decoration.EndCrystalEntity
 import net.minecraft.server.world.ServerWorld
+import net.minecraft.text.Text
 import net.minecraft.world.World
+import kotlin.math.ceil
 
 object DragonEventHandler {
+
+    private data class DelayState(
+        var delayActive: Boolean = false,
+        var ticksRemaining: Int = 0,
+        var initialSpawnAttemptProcessed: Boolean = false, // To ensure we only delay the *very first* attempt
+        var fightInstance: EnderDragonFight? = null // To store the fight instance for later spawning
+    )
+
+    private val worldDelayStates = mutableMapOf<ServerWorld, DelayState>()
 
     fun register() {
         ServerEntityEvents.ENTITY_LOAD.register { entity, world ->
@@ -19,6 +34,113 @@ object DragonEventHandler {
                 LOGGER.info("Ender Dragon detected loading in The End! Checking scaling conditions...")
                 // Delegate the actual scaling logic to DragonScaler
                 DragonScaler.scaleDragon(entity, world)
+            }
+        }
+
+        // Register for world ticks in The End to manage the countdown
+        ServerTickEvents.END_WORLD_TICK.register(::onWorldTick)
+
+        LOGGER.info("DragonEventHandler registered for spawn delay and scaling.")
+    }
+
+    /**
+     * Called from EnderDragonFightMixin to intercept the initial dragon spawn.
+     * Returns true if the original spawn should be cancelled (i.e., we are delaying it).
+     */
+    fun onInitialDragonPreSpawn(fight: EnderDragonFight, world: ServerWorld): Boolean {
+        if (world.registryKey != World.END) return false // Should always be The End from the mixin context
+
+        val state = worldDelayStates.computeIfAbsent(world) { DelayState() }
+
+        // Case 1: Feature is disabled in config
+        if (!ConfigManager.enableInitialSpawnDelay) {
+            state.initialSpawnAttemptProcessed = true // Mark as processed, feature disabled
+            if (state.delayActive) { // If a delay was somehow active and then config got disabled
+                state.delayActive = false
+                state.ticksRemaining = 0 // This will ensure any active countdown stops and tries to spawn
+                LOGGER.info("Initial spawn delay was active but config is now disabled. Dragon will attempt to spawn.")
+            }
+            return false // Do not cancel, let vanilla spawn proceed
+        }
+
+        // Case 2: Our timer has finished, and we are now programmatically triggering the spawn.
+        // `initialSpawnAttemptProcessed` will be true, and `delayActive` will be false.
+        if (state.initialSpawnAttemptProcessed && !state.delayActive) {
+            LOGGER.debug("Permitting dragon spawn triggered by delay completion.")
+            return false // Do not cancel, let our spawn proceed
+        }
+
+        // Case 3: Delay is currently active (timer is ticking down).
+        // This handles if vanilla code tries to spawn again while our timer is running.
+        if (state.delayActive) {
+            LOGGER.debug("Dragon spawn attempt while delay is_active. Cancelling vanilla spawn.")
+            return true // Cancel subsequent vanilla spawn attempts
+        }
+
+        // Case 4: This is the first time for this world, feature enabled, not yet processed, not active.
+        // This is where we initiate the delay.
+        // (state.initialSpawnAttemptProcessed is false here, or it would have hit Case 2 or 3)
+        LOGGER.info("Initial Ender Dragon spawn in ${world.registryKey.value} will be delayed by ${ConfigManager.initialSpawnDelaySeconds} seconds.")
+        state.delayActive = true
+        state.ticksRemaining = ConfigManager.initialSpawnDelaySeconds * 20 // 20 ticks per second
+        state.initialSpawnAttemptProcessed = true // Mark that we've handled the first attempt
+        state.fightInstance = fight // Store the fight instance to trigger spawn later
+
+        return true // Cancel the immediate vanilla spawn
+    }
+
+    private fun onWorldTick(world: ServerWorld) {
+        // This method is registered for END_WORLD_TICK, so world.registryKey should be World.END
+        // but a check doesn't hurt if you ever change registration.
+        if (world.registryKey != World.END) return
+
+        val state = worldDelayStates[world] ?: return // No state for this world, or delay not initiated
+
+        // Handle if feature gets disabled mid-countdown (e.g., via /reload and config change)
+        if (!ConfigManager.enableInitialSpawnDelay && state.delayActive) {
+            LOGGER.info("Initial spawn delay feature disabled mid-countdown for ${world.registryKey.value}. Triggering dragon spawn now.")
+            state.delayActive = false
+            state.ticksRemaining = 0 // This will trigger the spawn logic below immediately
+        }
+
+        if (state.delayActive && state.ticksRemaining > 0) {
+            state.ticksRemaining--
+
+            if (ConfigManager.showSpawnDelayCountdown) {
+                val remainingSeconds = ceil(state.ticksRemaining / 20.0).toInt()
+                if (remainingSeconds > 0) { // Only show if time is actually remaining
+                    val message = Text.literal("Dragon spawning in: $remainingSeconds...")
+                    world.players.forEach { player ->
+                        // Double-check player is in The End (should be, given END_WORLD_TICK)
+                        if (player.world.registryKey == World.END) {
+                            player.sendMessage(message, true) // 'true' sends to action bar
+                        }
+                    }
+                }
+            }
+
+            if (state.ticksRemaining <= 0) {
+                LOGGER.info("Initial spawn delay finished for ${world.registryKey.value}. Triggering Ender Dragon spawn.")
+                state.delayActive = false // Stop the delay state
+
+                state.fightInstance?.let { fight ->
+                    // This call will go through the EnderDragonFightMixin again.
+                    // onInitialDragonPreSpawn will see:
+                    // initialSpawnAttemptProcessed = true, delayActive = false.
+                    // So it returns false (don't cancel), allowing respawnDragon to proceed.
+                    // Cast to the accessor and call the invoker method
+                    if (fight is EnderDragonFightAccessor) {
+                        fight.callRespawnDragon(emptyList<EndCrystalEntity>()) // Use the accessor
+                        LOGGER.info("Ender Dragon respawn initiated by the mod after delay via accessor.")
+                    } else {
+                        LOGGER.error("Could not cast EnderDragonFight to EnderDragonFightAccessor. Dragon not spawned post-delay.")
+                    }
+                } ?: LOGGER.error("EnderDragonFight instance was null when trying to spawn dragon post-delay for ${world.registryKey.value}")
+
+                // Consider if you want to remove the state from worldDelayStates here
+                // if this is a strictly one-time event per world load.
+                // For now, leaving it allows it to correctly handle subsequent vanilla calls
+                // by returning false from onInitialDragonPreSpawn (Case 2).
             }
         }
     }

--- a/src/main/resources/scaleddragonfight.mixins.json
+++ b/src/main/resources/scaleddragonfight.mixins.json
@@ -4,6 +4,8 @@
   "package": "com.zephbyte.scaleddragonfight.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "EnderDragonFightAccessor",
+    "EnderDragonFightMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## ✨ Feature: Initial Ender Dragon Spawn Delay

This PR introduces a configurable delay for the Ender Dragon's initial spawn, with an optional action bar countdown.

### Key Changes:

*   **Configuration:**
    *   Added `enableInitialSpawnDelay`, `initialSpawnDelaySeconds`, and `showSpawnDelayCountdown` to `ConfigManager.kt`.
*   **Spawn Interception & Delay Logic:**
    *   `EnderDragonFightMixin.java` now targets `createDragon()` to intercept the initial spawn.
    *   `DragonEventHandler.kt` manages the delay timer, state (per-world), and action bar countdown.
*   **Post-Delay Spawning:**
    *   `EnderDragonFightAccessor.java` (Invoker Mixin) allows calling the private `respawnDragon()` method.
    *   `DragonEventHandler` uses this accessor to trigger the spawn after the delay.
*   **Robustness:**
    *   Differentiates between the initial vanilla spawn and the mod-initiated spawn.
    *   Handles mid-countdown config changes for the delay feature.

This provides server owners more control over the first Ender Dragon encounter.